### PR TITLE
A couple of typos in the proof of work code

### DIFF
--- a/src/node/main/node_config_command.ml
+++ b/src/node/main/node_config_command.ml
@@ -113,11 +113,11 @@ module Manpage = struct
         factory default one. \
         If additional command-line arguments are provided, \
         they will amend the generated file. \
-        It assumes that a configuration file already exists, \
+        It assumes that a configuration file already exists \
         and will abort otherwise." ;
     `P "$(b,init) is like reset but assumes that \
-        no configuration file is present, \
-        and will abort other otherwise." ;
+        no configuration file is present \
+        and will abort otherwise." ;
     `P "$(b,update) is the main option to edit the configuration file of Tezos. \
         It will parse command line arguments and add or replace corresponding \
         entries in the Tezos configuration file."

--- a/src/node/main/node_config_file.ml
+++ b/src/node/main/node_config_file.ml
@@ -189,7 +189,7 @@ let net =
       { expected_pow ; bootstrap_peers ;
         listen_addr ; closed ; limits })
     (obj5
-       (dft "expected-proof-or-work" float default_net.expected_pow)
+       (dft "expected-proof-of-work" float default_net.expected_pow)
        (dft "bootstrap-peers"
           (list string) default_net.bootstrap_peers)
        (opt "listen-addr" string)

--- a/src/node/main/node_identity_command.ml
+++ b/src/node/main/node_identity_command.ml
@@ -97,7 +97,7 @@ module Term = struct
     let doc =
       "Expected amount of proof-of-work for the node identity. \
        The optional parameter should be a float between 0 and 256, where
-       0 disable the proof-of-work mechanism. Default: 24" in
+       0 disables the proof-of-work mechanism." in
     Arg.(value & pos 1 (some float) None & info [] ~docv:"DIFFICULTY" ~doc)
 
   let term =
@@ -128,7 +128,7 @@ module Manpage = struct
         This is the default operation." ;
     `P "$(b,generate [difficulty]) generates an identity whose \
         proof of work stamp difficulty is at least equal to $(i,difficulty). \
-        The value provided must be a floating point number between 0 and 128. \
+        The value provided must be a floating point number between 0 and 256. \
         It roughly reflects the numbers of expected leading zeroes in the hash \
         of the identity data-structure. \
         Therefore, a value of 0 means no proof-of-work, and the difficulty \

--- a/src/node/main/node_identity_command.ml
+++ b/src/node/main/node_identity_command.ml
@@ -97,7 +97,7 @@ module Term = struct
     let doc =
       "Expected amount of proof-of-work for the node identity. \
        The optional parameter should be a float between 0 and 256, where
-       0 disable the proof-of-work mechanism." in
+       0 disable the proof-of-work mechanism. Default: 24" in
     Arg.(value & pos 1 (some float) None & info [] ~docv:"DIFFICULTY" ~doc)
 
   let term =


### PR DESCRIPTION
I'm mostly just reading through random code and trying to pick up things.  There's only one real bug here, which is that it's looking for proof-or-work instead of proof-of-work in the config file.  The rest is just help-desc changes.