### PR TITLE
doc typo set::MEM (again)

### DIFF
--- a/src/proto/alpha/docs/language.md
+++ b/src/proto/alpha/docs/language.md
@@ -750,7 +750,7 @@ constants as is, concatenate them and use them as keys.
    * `MEM`:
      Check for the presence of an element in a set.
 
-        :: 'key : set 'elt : 'S   ->  bool : 'S
+        :: 'elt : set 'elt : 'S   ->  bool : 'S
 
    * `UPDATE`:
      Inserts or removes an element in a set, replacing a previous value.


### PR DESCRIPTION
This pull request is identical to recently closed #19, but applied to the current head. I think #19 may have been closed erroneously. If MEM takes as an input a set of elements of type 'elt, then if it also takes another input which is an element to test for membership, clearly that other input must be of type 'elt.

If #19 was not closed erroneously, then please explain, and i will stop reopening this issue.