### PR TITLE
Move compose function (<<) to end of file

### DIFF
--- a/src/minutils/utils.ml
+++ b/src/minutils/utils.ml
@@ -188,7 +188,7 @@ let write_file ?(bin=false) fn contents =
     )
     (fun () -> close_out oc)
 
-let (<<) g f = fun a -> g (f a)
+
 
 let rec (--) i j =
   let rec loop acc j =
@@ -303,3 +303,5 @@ let parse_addr_port s =
             | _pos ->
                 invalid_arg "split_url_port: IPv6 addresses must be bracketed"
   end
+
+let (<<) g f = fun a -> g (f a)

--- a/src/minutils/utils.mli
+++ b/src/minutils/utils.mli
@@ -70,8 +70,6 @@ val finalize: (unit -> 'a) -> (unit -> unit) -> 'a
 val read_file: ?bin:bool -> string -> string
 val write_file: ?bin:bool -> string -> string -> unit
 
-(** Compose functions from right to left. *)
-val (<<) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c
 
 (** Sequence: [i--j] is the sequence [i;i+1;...;j-1;j] *)
 val (--) : int -> int -> int list
@@ -95,3 +93,6 @@ val select: int -> 'a list -> 'a * 'a list
 (** [split_url_port uri] is (node, service) where [node] is the DNS or
     IP and service is the optional port number or service name. *)
 val parse_addr_port: string -> string * string
+
+(** Compose functions from right to left. *)
+val (<<) : ('b -> 'c) -> ('a -> 'b) -> 'a -> 'c


### PR DESCRIPTION
It's screwing up emacs font locking.