### PR TITLE
Fix ISSUE_TEMPLATE symlink

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,1 +1,1 @@
-.gitlab/issue_templates/issues.md
+../.gitlab/issue_templates/issues.md


### PR DESCRIPTION
The wrong symlink led to messages like these in the `make build-steps`
output:

    [WARNING] Rsync partially failed:
              symlink has no referent: "/mnt/data/Projects/tezos/.github/ISSUE_TEMPLATE.md"
              rsync error: some files/attrs were not transferred (see previous errors) (code 23)
              at
              main.c(1178) [sender=3.1.2]